### PR TITLE
IsMouseVisible & SetPosition fix for WinDX.

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -73,6 +73,15 @@ namespace Microsoft.Xna.Framework.Input
             Window = window;
             _mouse = window.Mouse;        
         }
+
+#elif (WINDOWS && DIRECTX)
+
+        static System.Windows.Forms.Form Window;
+
+        internal static void setWindows(System.Windows.Forms.Form window)
+        {
+            Window = window;
+        }
         
 #elif LINUX         
         
@@ -141,12 +150,12 @@ namespace Microsoft.Xna.Framework.Input
         {
             UpdateStatePosition(x, y);
 
-#if (WINDOWS && OPENGL) || LINUX
-            ///correcting the coordinate system
-            ///Only way to set the mouse position !!!
-            System.Drawing.Point pt = Window.PointToScreen(new System.Drawing.Point(x, y));
+#if (WINDOWS && (OPENGL || DIRECTX)) || LINUX
+            // correcting the coordinate system
+            // Only way to set the mouse position !!!
+            var pt = Window.PointToScreen(new System.Drawing.Point(x, y));
 #elif WINDOWS
-            var pt = new System.Drawing.Point(0,0);
+            var pt = new System.Drawing.Point(0, 0);
 #endif
 
 #if WINDOWS

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -85,6 +85,8 @@ namespace MonoGame.Framework
         {
             _window = new WinFormsGameWindow(this);
             Window = _window;
+
+            this.IsMouseVisible = true;
         }
 
         public override GameRunBehavior DefaultRunBehavior
@@ -101,7 +103,6 @@ namespace MonoGame.Framework
 
         public override void RunLoop()
         {
-            OnIsMouseVisibleChanged();
             _window.RunLoop();
         }
 

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -111,6 +111,8 @@ namespace MonoGame.Framework
             _form = new Form();
             _form.Icon = Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly().Location);
 
+            Mouse.setWindows(_form);
+
             // Capture mouse and keyboard events.
             _form.MouseDown += OnMouseState;
             _form.MouseMove += OnMouseState;


### PR DESCRIPTION
- Set IsMouseVisible to true by default as like in WindowsGL version. (https://github.com/mono/MonoGame/pull/837 - c45d69ce6a0d992e36ab148f21719cac2dd3bea5)
- Fixed SetPosition for windesktop so that it correctly position with PointToScreen.
