### PR TITLE
Fix/content fixes patch

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderParams.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderParams.cs
@@ -312,7 +312,7 @@ public class ContentBuilderParams
 
     private static string MakeRelative(string workingDir, string path)
     {
-        if (!Path.IsPathRooted(path))
+        if (Path.IsPathRooted(path))
             return FileHelper.NormalizeSeparators(path, true);
 
         // Note this may still return an absolute path in the case

--- a/Tools/MonoGame.Tools.Tests/BuilderTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BuilderTests.cs
@@ -164,9 +164,9 @@ namespace MonoGame.Tests.ContentPipeline
                 "-o", MakePath(Directory.GetCurrentDirectory(), "Other/Folder"),
                 "-i", MakePath(Directory.GetCurrentDirectory(), "Folder")
             );
-            Assert.AreEqual(MakePath("../Some/Folder"), args.SourceDirectory);
-            Assert.AreEqual(MakePath("Other/Folder"), args.OutputDirectory);
-            Assert.AreEqual(MakePath("Folder"), args.IntermediateDirectory);
+            Assert.AreEqual(MakePath(Directory.GetCurrentDirectory(), "../Some/Folder"), args.SourceDirectory);
+            Assert.AreEqual(MakePath(Directory.GetCurrentDirectory(), "Other/Folder"), args.OutputDirectory);
+            Assert.AreEqual(MakePath(Directory.GetCurrentDirectory(), "Folder"), args.IntermediateDirectory);
 
             args = ContentBuilderParams.Parse("server");
             Assert.AreEqual(ContentBuilderMode.Server, args.Mode);


### PR DESCRIPTION
# Summary

Resolve Unit test issues:

- Path.IsRooted test was inverted, absolute paths need only be sanitised
- BuilderTests user using different inputs to assert