### PR TITLE
Fixing DX12 Test Crashes and Failures

### DIFF
--- a/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
@@ -89,6 +89,10 @@ namespace MonoGame.Tests.Graphics
             gdm = null;
             gd = null;
             content = null;
+            
+            // Force GC to ensure both system and GPU memory is freed up between tests.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
 
             if (_framePrepared && !_framesChecked)
                 Assert.Fail("Initialized fixture for rendering but did not check frames.");

--- a/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
@@ -89,10 +89,6 @@ namespace MonoGame.Tests.Graphics
             gdm = null;
             gd = null;
             content = null;
-            
-            // Force GC to ensure both system and GPU memory is freed up between tests.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
 
             if (_framePrepared && !_framesChecked)
                 Assert.Fail("Initialized fixture for rendering but did not check frames.");

--- a/Tests/Framework/Graphics/Texture2DThreadingTests.cs
+++ b/Tests/Framework/Graphics/Texture2DThreadingTests.cs
@@ -100,6 +100,7 @@ namespace MonoGame.Tests.Graphics
                 barrier.RemoveParticipant();
             });
 
+            thread.IsBackground = true;
             thread.Start();
 
             int frames = 0;

--- a/Tests/Runner/Desktop/FramePixelData.cs
+++ b/Tests/Runner/Desktop/FramePixelData.cs
@@ -26,7 +26,9 @@ namespace MonoGame.Tests
 
         public unsafe void Save(string filename, string attachmentDescription = null)
         {
-			using (var stream = new FileStream(filename, FileMode.Create))
+            var fullPath = Path.GetFullPath(filename);
+
+            using (var stream = new FileStream(fullPath, FileMode.Create))
 			{
 				fixed (Color* ptr = &Data[0])
 				{
@@ -42,7 +44,6 @@ namespace MonoGame.Tests
 
             if (attachmentDescription != null)
             {
-                var fullPath = Path.GetFullPath(filename);
                 NUnit.Framework.TestContext.AddTestAttachment(fullPath, attachmentDescription);
             }
         }

--- a/Tests/Runner/Desktop/FramePixelData.cs
+++ b/Tests/Runner/Desktop/FramePixelData.cs
@@ -42,7 +42,8 @@ namespace MonoGame.Tests
 
             if (attachmentDescription != null)
             {
-                NUnit.Framework.TestContext.AddTestAttachment(filename, attachmentDescription);
+                var fullPath = Path.GetFullPath(filename);
+                NUnit.Framework.TestContext.AddTestAttachment(fullPath, attachmentDescription);
             }
         }
     }

--- a/native/monogame/directx12/CommandQueue.cpp
+++ b/native/monogame/directx12/CommandQueue.cpp
@@ -117,6 +117,9 @@ void CommandQueue::ResumeX() {
 #endif
 
 CommandList* CommandListPool::Begin() {
+    // Ensure m_fenceMutex is acquired before m_mutex.
+    uint64_t currentFence = m_queue->PollCurrentFenceValue();
+
     CommandList* ctx = nullptr;
 
     std::lock_guard lock(m_mutex);
@@ -124,12 +127,12 @@ CommandList* CommandListPool::Begin() {
     if (m_contextsRepo.empty()) {
         ctx = new CommandList(this);
         m_contexts.emplace_back(ctx);
-        ctx->m_allocator = NewAllocator(m_queue->PollCurrentFenceValue());
+        ctx->m_allocator = NewAllocator(currentFence);
         ThrowIfFailed(m_device->CreateCommandList(0, m_queue->GetType(), ctx->m_allocator, nullptr, IID_GRAPHICS_PPV_ARGS(ctx->m_list.ReleaseAndGetAddressOf())));
         ctx->m_list->SetName((m_name + L" CommandList").c_str());
     } else {
         ctx = m_contextsRepo.front();
-        ctx->m_allocator = NewAllocator(m_queue->PollCurrentFenceValue());
+        ctx->m_allocator = NewAllocator(currentFence);
         ctx->m_list->Reset(ctx->m_allocator, nullptr);
         m_contextsRepo.pop();
     }
@@ -139,6 +142,7 @@ CommandList* CommandListPool::Begin() {
 
 uint64_t CommandListPool::CloseList(CommandList* ctx, bool blocking)
 {
+    // Ensure m_fenceMutex is acquired before m_mutex.
     uint64_t fenceValue = m_queue->ExecuteCommandList(ctx->m_list.Get());
 
     if (blocking)

--- a/native/monogame/directx12/CommandQueue.cpp
+++ b/native/monogame/directx12/CommandQueue.cpp
@@ -29,9 +29,14 @@ uint64_t CommandQueue::ExecuteCommandList(ID3D12CommandList* commandList)
 {
     // Send the command list off to the GPU for processing.
     ThrowIfFailed(((ID3D12GraphicsCommandList*)commandList)->Close());
+
+    // Make sure the fence covers ExecuteCommandLists call.
+    std::lock_guard lock(m_fenceMutex);
     m_queue->ExecuteCommandLists(1, &commandList);
 
-    return SignalFence();
+    m_queue->Signal(m_fence.Get(), m_nextFenceValue);
+
+    return m_nextFenceValue++;
 }
 
 uint64_t CommandQueue::SignalFence()

--- a/native/monogame/directx12/CommandQueue.cpp
+++ b/native/monogame/directx12/CommandQueue.cpp
@@ -66,9 +66,25 @@ void CommandQueue::WaitForFenceCPUBlocking(uint64_t fenceValue)
         return;
 
     HANDLE evt = CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE);
-    m_fence->SetEventOnCompletion(fenceValue, evt);
-    WaitForSingleObjectEx(evt, INFINITE, FALSE);
+    HRESULT hr = m_fence->SetEventOnCompletion(fenceValue, evt);
+    ThrowIfFailed(hr);
+
+    // 5 seconds should be more than enough.
+    // https://learn.microsoft.com/en-us/windows-hardware/drivers/display/timeout-detection-and-recovery
+    // "The default timeout period in Windows is two seconds."
+    // "If the GPU can't complete or preempt the current task within the TDR timeout period, the OS diagnoses that the GPU is frozen."
+    DWORD waitResult = WaitForSingleObjectEx(evt, 5000, FALSE);
+
     CloseHandle(evt);
+    if (waitResult == WAIT_TIMEOUT)
+    {
+        ThrowIfFailed(DXGI_ERROR_DEVICE_HUNG);
+    }
+    else if (waitResult == WAIT_FAILED)
+    {
+        DWORD win32Error = GetLastError();
+        ThrowIfFailed(HRESULT_FROM_WIN32(win32Error));
+    }
 
     std::lock_guard lock(m_fenceMutex);
     m_lastCompletedFenceValue = fenceValue;

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -732,8 +732,8 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
     {
         // TODO: These should be configurable.
         // https://github.com/MonoGame/MonoGame/issues/9382
-        constexpr size_t MAX_BUFFER_POOL_SIZE = 16;
-	    constexpr size_t MIN_BUFFER_POOL_SIZE = 8;
+        constexpr size_t MAX_BUFFER_POOL_SIZE = 64;
+	    constexpr size_t MIN_BUFFER_POOL_SIZE = 32;
 
         // Evict old buffers that are too small to reduce memory pressure.
         // This will likely mean we'll keep creating larger and larger buffers.

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -246,7 +246,11 @@ public:
             desc.pDevice = m_d3dDevice.Get();
 #if !defined(_GAMING_XBOX)
             desc.pAdapter = adapter;
-            desc.PreferredBlockSize = 4ull * 1024 * 1024;   // 4 MB instead of default 64MB.
+
+            // TODO: This really needs to be configurable.
+            // Another reason for:
+            // // https://github.com/MonoGame/MonoGame/issues/9382
+            desc.PreferredBlockSize = 4ull * 1024 * 1024;   // 4 MB instead of default 64MB that it defaults to.
 #else
             Microsoft::WRL::ComPtr<IDXGIDevice1> dxgiDevice;
             Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -728,7 +728,24 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
     }
 
     if (buffer == nullptr)
-    { 
+    {
+        // Evict old buffers that are too small to reduce memory pressure.
+        // This will likely mean we'll keep creating larger and larger buffers.
+		// It's not ideal. Should we have more sophisticated memory management?
+        auto evictionIter = pImpl->m_tempBuffers.begin();
+        while (evictionIter != pImpl->m_tempBuffers.end())
+        {
+            if (evictionIter->fence <= fence
+                && evictionIter->desc.Width < desc.Width)
+            {
+                evictionIter = pImpl->m_tempBuffers.erase(evictionIter);
+            }
+            else
+            {
+                ++evictionIter;
+            }
+        }
+
         Impl::TempBuffer upload;
         upload.fence = UINT64_MAX;  // TODO: Handle fence wrap.
         upload.desc = desc;

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -731,16 +731,16 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
     {
         // TODO: These should be configurable.
         // https://github.com/MonoGame/MonoGame/issues/9382
-        constexpr size_t MAX_BUFFER_POOL_SIZE = 32;
-	    constexpr size_t MIN_BUFFER_POOL_SIZE = 16;
+        constexpr size_t MAX_BUFFER_POOL_SIZE = 16;
+	    constexpr size_t MIN_BUFFER_POOL_SIZE = 8;
 
         // Evict old buffers that are too small to reduce memory pressure.
         // This will likely mean we'll keep creating larger and larger buffers.
 		// It's not ideal. Should we have more sophisticated memory management?
-        if (pImpl->m_tempBuffers.size() > MAX_BUFFER_POOL_SIZE)
+        if (pImpl->m_tempBuffers.size() >= MAX_BUFFER_POOL_SIZE)
         {
             auto evictionIter = pImpl->m_tempBuffers.begin();
-            while (pImpl->m_tempBuffers.size() > MIN_BUFFER_POOL_SIZE
+            while (pImpl->m_tempBuffers.size() >= MIN_BUFFER_POOL_SIZE
                 && evictionIter != pImpl->m_tempBuffers.end())
             {
                 if (evictionIter->fence <= fence

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -729,23 +729,27 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
 
     if (buffer == nullptr)
     {
-	    constexpr size_t MIN_BUFFER_POOL_SIZE = 64;
+        constexpr size_t MAX_BUFFER_POOL_SIZE = 32;
+	    constexpr size_t MIN_BUFFER_POOL_SIZE = 16;
 
         // Evict old buffers that are too small to reduce memory pressure.
         // This will likely mean we'll keep creating larger and larger buffers.
 		// It's not ideal. Should we have more sophisticated memory management?
-        auto evictionIter = pImpl->m_tempBuffers.begin();
-        while (pImpl->m_tempBuffers.size() > MIN_BUFFER_POOL_SIZE
-			&& evictionIter != pImpl->m_tempBuffers.end())
+        if (pImpl->m_tempBuffers.size() > MAX_BUFFER_POOL_SIZE)
         {
-            if (evictionIter->fence <= fence
-                && evictionIter->desc.Width < desc.Width)
+            auto evictionIter = pImpl->m_tempBuffers.begin();
+            while (pImpl->m_tempBuffers.size() > MIN_BUFFER_POOL_SIZE
+                && evictionIter != pImpl->m_tempBuffers.end())
             {
-                evictionIter = pImpl->m_tempBuffers.erase(evictionIter);
-            }
-            else
-            {
-                ++evictionIter;
+                if (evictionIter->fence <= fence
+                    && evictionIter->desc.Width < desc.Width)
+                {
+                    evictionIter = pImpl->m_tempBuffers.erase(evictionIter);
+                }
+                else
+                {
+                    ++evictionIter;
+                }
             }
         }
 

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -729,6 +729,8 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
 
     if (buffer == nullptr)
     {
+        // TODO: These should be configurable.
+        // https://github.com/MonoGame/MonoGame/issues/9382
         constexpr size_t MAX_BUFFER_POOL_SIZE = 32;
 	    constexpr size_t MIN_BUFFER_POOL_SIZE = 16;
 

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -763,7 +763,7 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
 
         // ALLOCATION_FLAG_COMMITTED uses dedicated allocation.
         // ALLOCATION_FLAG_NONE places the resource into existing preallocated pool.
-        D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_NONE, type };
+        D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_COMMITTED, type };
         HRESULT hr = pImpl->m_allocator->CreateResource(
             &allocDesc, &desc,
             state, nullptr,

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -702,7 +702,7 @@ Texture* Graphics::DeviceResources::GetMainTarget() const noexcept {
     return pImpl->GetMainTarget();
 }
 
-ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type, D3D12_RESOURCE_STATES state, D3D12_RESOURCE_DESC& desc)
+ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type, D3D12_RESOURCE_STATES state, D3D12_RESOURCE_DESC& desc) const
 {
     std::lock_guard<std::mutex> lock(pImpl->m_bufferMutex);
 
@@ -735,14 +735,20 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
         upload.type = type;
 
         D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_COMMITTED, type };
-        pImpl->m_allocator->CreateResource(
+        HRESULT hr = pImpl->m_allocator->CreateResource(
             &allocDesc, &desc,
             state, nullptr,
             upload.alloc.ReleaseAndGetAddressOf(),
             IID_GRAPHICS_PPV_ARGS(upload.buffer.ReleaseAndGetAddressOf()));
 
-        upload.buffer->SetName(L"tempBuffer");
-        upload.alloc->SetName(L"tempAlloc");
+        ThrowIfFailed(hr);
+
+        if (upload.buffer)
+            upload.buffer->SetName(L"tempBuffer");
+
+        if (upload.alloc)
+            upload.alloc->SetName(L"tempAlloc");
+
         pImpl->m_tempBuffers.push_back(upload);
 
         buffer = upload.buffer.Get();

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -44,7 +44,7 @@ private:
     std::unique_ptr<CommandContext> m_commandContext;
     std::unique_ptr<Heaps> m_heaps;
     Microsoft::WRL::ComPtr<D3D12MA::Allocator> m_allocator;
-    Microsoft::WRL::ComPtr<D3D12MA::Pool> m_transientBufferPool;
+    //Microsoft::WRL::ComPtr<D3D12MA::Pool> m_transientBufferPool;
 
     struct TempBuffer
     {
@@ -87,7 +87,7 @@ public:
 
         m_tempBuffers.clear();
         m_commandContext.reset();
-        m_transientBufferPool.Reset();
+        //m_transientBufferPool.Reset();
         m_heaps.reset();
         m_commandListPool.reset();
         m_queue.reset();
@@ -255,14 +255,14 @@ public:
 #endif
             D3D12MA::CreateAllocator(&desc, &m_allocator);
 
-            D3D12MA::POOL_DESC poolDesc = {};
-            poolDesc.HeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD; // We use an UPLOAD heap for temporary VBs/IBs (best for CPU-write-once, GPU-read-once data cf https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_type#constants)
-            poolDesc.Flags = D3D12MA::POOL_FLAG_ALGORITHM_LINEAR;
-            poolDesc.HeapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
-            poolDesc.BlockSize = MAX_BACK_BUFFER_COUNT * MAX_BUFFER_PER_FRAME * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT; // Alignment of buffers is always 64KB
-            poolDesc.MinBlockCount = poolDesc.MaxBlockCount = 1;
-            poolDesc.MaxBlockCount = 1;
-            m_allocator->CreatePool(&poolDesc, &m_transientBufferPool);
+            //D3D12MA::POOL_DESC poolDesc = {};
+            //poolDesc.HeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD; // We use an UPLOAD heap for temporary VBs/IBs (best for CPU-write-once, GPU-read-once data cf https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_type#constants)
+            //poolDesc.Flags = D3D12MA::POOL_FLAG_ALGORITHM_LINEAR;
+            //poolDesc.HeapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
+            //poolDesc.BlockSize = MAX_BACK_BUFFER_COUNT * MAX_BUFFER_PER_FRAME * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT; // Alignment of buffers is always 64KB
+            //poolDesc.MinBlockCount = poolDesc.MaxBlockCount = 1;
+            //poolDesc.MaxBlockCount = 1;
+            //m_allocator->CreatePool(&poolDesc, &m_transientBufferPool);
         }
 
         m_commandContext = std::make_unique<CommandContext>(device);
@@ -472,7 +472,7 @@ public:
         m_commandListPool.reset();
         m_queue.reset();
         m_heaps.reset();
-        m_transientBufferPool.Reset();
+        //m_transientBufferPool.Reset();
         m_swapChain.Reset();
         m_d3dDevice.Reset();
         m_dxgiFactory.Reset();
@@ -694,9 +694,9 @@ D3D12MA::Allocator* Graphics::DeviceResources::GetAllocator() const {
     return pImpl->m_allocator.Get();
 }
 
-D3D12MA::Pool* Graphics::DeviceResources::GetTransientBufferPool() const {
-    return pImpl->m_transientBufferPool.Get();
-}
+//D3D12MA::Pool* Graphics::DeviceResources::GetTransientBufferPool() const {
+//    return pImpl->m_transientBufferPool.Get();
+//}
 
 Texture* Graphics::DeviceResources::GetMainTarget() const noexcept {
     return pImpl->GetMainTarget();

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -44,7 +44,7 @@ private:
     std::unique_ptr<CommandContext> m_commandContext;
     std::unique_ptr<Heaps> m_heaps;
     Microsoft::WRL::ComPtr<D3D12MA::Allocator> m_allocator;
-    //Microsoft::WRL::ComPtr<D3D12MA::Pool> m_transientBufferPool;
+    Microsoft::WRL::ComPtr<D3D12MA::Pool> m_transientBufferPool;
 
     struct TempBuffer
     {
@@ -87,7 +87,7 @@ public:
 
         m_tempBuffers.clear();
         m_commandContext.reset();
-        //m_transientBufferPool.Reset();
+        m_transientBufferPool.Reset();
         m_heaps.reset();
         m_commandListPool.reset();
         m_queue.reset();
@@ -255,14 +255,14 @@ public:
 #endif
             D3D12MA::CreateAllocator(&desc, &m_allocator);
 
-            //D3D12MA::POOL_DESC poolDesc = {};
-            //poolDesc.HeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD; // We use an UPLOAD heap for temporary VBs/IBs (best for CPU-write-once, GPU-read-once data cf https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_type#constants)
-            //poolDesc.Flags = D3D12MA::POOL_FLAG_ALGORITHM_LINEAR;
-            //poolDesc.HeapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
-            //poolDesc.BlockSize = MAX_BACK_BUFFER_COUNT * MAX_BUFFER_PER_FRAME * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT; // Alignment of buffers is always 64KB
-            //poolDesc.MinBlockCount = poolDesc.MaxBlockCount = 1;
-            //poolDesc.MaxBlockCount = 1;
-            //m_allocator->CreatePool(&poolDesc, &m_transientBufferPool);
+            D3D12MA::POOL_DESC poolDesc = {};
+            poolDesc.HeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD; // We use an UPLOAD heap for temporary VBs/IBs (best for CPU-write-once, GPU-read-once data cf https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_type#constants)
+            poolDesc.Flags = D3D12MA::POOL_FLAG_ALGORITHM_LINEAR;
+            poolDesc.HeapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
+            poolDesc.BlockSize = MAX_BACK_BUFFER_COUNT * MAX_BUFFER_PER_FRAME * D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT; // Alignment of buffers is always 64KB
+            poolDesc.MinBlockCount = poolDesc.MaxBlockCount = 1;
+            poolDesc.MaxBlockCount = 1;
+            m_allocator->CreatePool(&poolDesc, &m_transientBufferPool);
         }
 
         m_commandContext = std::make_unique<CommandContext>(device);
@@ -472,7 +472,7 @@ public:
         m_commandListPool.reset();
         m_queue.reset();
         m_heaps.reset();
-        //m_transientBufferPool.Reset();
+        m_transientBufferPool.Reset();
         m_swapChain.Reset();
         m_d3dDevice.Reset();
         m_dxgiFactory.Reset();
@@ -694,9 +694,9 @@ D3D12MA::Allocator* Graphics::DeviceResources::GetAllocator() const {
     return pImpl->m_allocator.Get();
 }
 
-//D3D12MA::Pool* Graphics::DeviceResources::GetTransientBufferPool() const {
-//    return pImpl->m_transientBufferPool.Get();
-//}
+D3D12MA::Pool* Graphics::DeviceResources::GetTransientBufferPool() const {
+    return pImpl->m_transientBufferPool.Get();
+}
 
 Texture* Graphics::DeviceResources::GetMainTarget() const noexcept {
     return pImpl->GetMainTarget();

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -729,11 +729,14 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
 
     if (buffer == nullptr)
     {
+	    constexpr size_t MIN_BUFFER_POOL_SIZE = 64;
+
         // Evict old buffers that are too small to reduce memory pressure.
         // This will likely mean we'll keep creating larger and larger buffers.
 		// It's not ideal. Should we have more sophisticated memory management?
         auto evictionIter = pImpl->m_tempBuffers.begin();
-        while (evictionIter != pImpl->m_tempBuffers.end())
+        while (pImpl->m_tempBuffers.size() > MIN_BUFFER_POOL_SIZE
+			&& evictionIter != pImpl->m_tempBuffers.end())
         {
             if (evictionIter->fence <= fence
                 && evictionIter->desc.Width < desc.Width)

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -760,7 +760,9 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
         upload.desc = desc;
         upload.type = type;
 
-        D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_COMMITTED, type };
+        // ALLOCATION_FLAG_COMMITTED uses dedicated allocation.
+        // ALLOCATION_FLAG_NONE places the resource into existing preallocated pool.
+        D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_NONE, type };
         HRESULT hr = pImpl->m_allocator->CreateResource(
             &allocDesc, &desc,
             state, nullptr,

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -246,6 +246,7 @@ public:
             desc.pDevice = m_d3dDevice.Get();
 #if !defined(_GAMING_XBOX)
             desc.pAdapter = adapter;
+            desc.PreferredBlockSize = 4ull * 1024 * 1024;   // 4 MB instead of default 64MB.
 #else
             Microsoft::WRL::ComPtr<IDXGIDevice1> dxgiDevice;
             Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -723,14 +723,14 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
             continue;
 
         buffer = iter->buffer.Get();
-        iter->fence = 0;
+        iter->fence = UINT64_MAX;
         break;
     }
 
     if (buffer == nullptr)
     { 
         Impl::TempBuffer upload;
-        upload.fence = 0;
+        upload.fence = UINT64_MAX;
         upload.desc = desc;
         upload.type = type;
 

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -723,14 +723,14 @@ ID3D12Resource* Graphics::DeviceResources::TakeUploadBuffer(D3D12_HEAP_TYPE type
             continue;
 
         buffer = iter->buffer.Get();
-        iter->fence = UINT64_MAX;
+		iter->fence = UINT64_MAX;   // TODO: Handle fence wrap.
         break;
     }
 
     if (buffer == nullptr)
     { 
         Impl::TempBuffer upload;
-        upload.fence = UINT64_MAX;
+        upload.fence = UINT64_MAX;  // TODO: Handle fence wrap.
         upload.desc = desc;
         upload.type = type;
 

--- a/native/monogame/directx12/DeviceResources.h
+++ b/native/monogame/directx12/DeviceResources.h
@@ -71,7 +71,7 @@ public:
     D3D12MA::Pool* GetTransientBufferPool() const;
     Texture* GetMainTarget() const noexcept;
 
-    ID3D12Resource* TakeUploadBuffer(D3D12_HEAP_TYPE type, D3D12_RESOURCE_STATES state, D3D12_RESOURCE_DESC& desc);
+    ID3D12Resource* TakeUploadBuffer(D3D12_HEAP_TYPE type, D3D12_RESOURCE_STATES state, D3D12_RESOURCE_DESC& desc) const;
     void ReturnUploadBuffer(ID3D12Resource* buffer, uint64_t fence);
 };
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1154,7 +1154,7 @@ void MGDX_ApplyState(MGG_GraphicsDevice* device)
 			// TODO: We should be using a commutative hash in SetSamplerState.
 			// TODO: Hashing the pointers can be dangerous... use unique ids.
 
-			uint32_t hash = MG_ComputeHash((mgbyte*)device->samplers[s], maxSlot * sizeof(MGG_SamplerState*));
+			uint32_t hash = MG_ComputeHash(reinterpret_cast<mgbyte*>(device->samplers[s]), (maxSlot + 1) * sizeof(MGG_SamplerState*));
 			auto iter = device->samplerSetHandles.find(hash);			
 			if (iter != device->samplerSetHandles.end())
 			{

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -531,6 +531,18 @@ void MGG_GraphicsDevice_Destroy(MGG_GraphicsDevice* device)
 	if (device->depthTexture)
 		delete device->depthTexture;
 
+	for (auto discardedBuffer : device->discarded)
+		delete discardedBuffer;
+	device->discarded.clear();
+
+	for (auto pendingBuffer : device->pending)
+		delete pendingBuffer;
+	device->pending.clear();
+
+	for (auto freeBuffer : device->free)
+		delete freeBuffer;
+	device->free.clear();
+
 	delete device->pipelineManager;
 	delete device->resources;
 

--- a/native/monogame/directx12/Texture.cpp
+++ b/native/monogame/directx12/Texture.cpp
@@ -128,7 +128,9 @@ void Texture::Create(DeviceResources* device, bool createViews) {
     if (impl->m_allowUAV)
         resDesc.Format = ConvertSRVtoResourceFormat(impl->m_desc.Format);
 
-    D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_COMMITTED, D3D12_HEAP_TYPE_DEFAULT, heapFlags };
+    // ALLOCATION_FLAG_COMMITTED uses dedicated allocation.
+    // ALLOCATION_FLAG_NONE places the resource into existing preallocated pool.
+    D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_NONE, D3D12_HEAP_TYPE_DEFAULT, heapFlags };
 
     ThrowIfFailed(device->GetAllocator()->CreateResource(
         &allocDesc,

--- a/native/monogame/directx12/directx12.h
+++ b/native/monogame/directx12/directx12.h
@@ -129,9 +129,11 @@ namespace DX {
     inline void ThrowIfFailed(HRESULT hr)
     {
         if (FAILED(hr)) {
-#ifdef _DEBUG
             char str[64] = {};
             sprintf_s(str, "**ERROR** Fatal Error with HRESULT of %08X\n", static_cast<unsigned int>(hr));
+            fprintf(stderr, "%s", str);
+            fflush(stderr);
+#ifdef _DEBUG
             OutputDebugStringA(str);
             if (IsDebuggerPresent())
                 __debugbreak();

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -4827,7 +4827,8 @@ static MGG_Buffer* MGVK_BufferDiscard(MGG_GraphicsDevice* device, MGG_Buffer* bu
 	}
 
 	// We didn't find a match, so allocate a new one.
-	buffer = MGG_Buffer_Create(device, type, false, dataSize);
+	auto dynamic = type == MGBufferType::Constant;
+	buffer = MGG_Buffer_Create(device, type, dynamic, dataSize);
 
 	return buffer;
 }

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1691,15 +1691,8 @@ void MGG_GraphicsDevice_Destroy(MGG_GraphicsDevice* device)
 	for (int i=0; i < 3; i++)
 		MGG_Texture_Destroy(device, device->nullTexture[i]);
 
-	if (device->swapchainCount > 0)
-	{
-		for (size_t i = 0; i < device->swapchainCount; i++)
-			MGVK_DestroyFrameResources(device, i, true);
-	}
-	else
-	{
-		MGVK_DestroyFrameResources(device, 0, true);
-	}
+	for (size_t i = 0; i < device->swapchainCount; i++)
+		MGVK_DestroyFrameResources(device, i, true);
 
 	if (device->surface != nullptr)
 		vkDestroySurfaceKHR(device->instance, device->surface, nullptr);

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1691,8 +1691,15 @@ void MGG_GraphicsDevice_Destroy(MGG_GraphicsDevice* device)
 	for (int i=0; i < 3; i++)
 		MGG_Texture_Destroy(device, device->nullTexture[i]);
 
-	for (size_t i = 0; i < device->swapchainCount; i++)
-		MGVK_DestroyFrameResources(device, i, true);
+	if (device->swapchainCount > 0)
+	{
+		for (size_t i = 0; i < device->swapchainCount; i++)
+			MGVK_DestroyFrameResources(device, i, true);
+	}
+	else
+	{
+		MGVK_DestroyFrameResources(device, 0, true);
+	}
 
 	if (device->surface != nullptr)
 		vkDestroySurfaceKHR(device->instance, device->surface, nullptr);


### PR DESCRIPTION
Fixing crashing test process.
This includes a bunch of thread safety and error handling fixes, and some minor changes to tests.

> [!TIP]
> We have resolved all off the OOM errors.
> All the tests pass.

DX12 Changes:
-
- Putting `ExecuteCommandLists` call behind the fence in `CommandQueue`.
   - The gap between `ExecuteCommandLists` call and the fence signal causes background loader threads to cause out of memory error on the test runner.
- Adding `HRESULT` handling in a bunch of places.
- Fixing `m_fenceMutex` and `m_mutex` order in `CommandListPool::Begin`
- Setting a 5 second timeout in `WaitForFenceCPUBlocking` instead of `INFINITE`, because Windows kernel resets GPU when it's unresponsive for 2 seconds.
   - I think 5 seconds should be a reasonable limit for other platforms as well.
- Setting `fence` as `UINT64_MAX` instead of `0` in `TakeUploadBuffer`.
   - Because I suspect setting it as 0 can cause another thread to pick it up before it's set to its actual value, causing both threads to use the same buffer, hence data corruption.
- Deleting `discarded`, `pending` and `free` contents in in `MGG_GraphicsDevice_Destroy`.
   - We have these arrays of pointers, but I think we're not actually deleting the buffers the pointers are pointing at.
- Fixing length calculation for `MG_ComputeHash` call in `MGDX_ApplyState`.
`maxSamplerSlot` seems to be a 0-based index, not count. We were calculating the length wrong.
- Added a basic cache eviction logic in `TakeUploadBuffer` to keep the number of buffers to a maximum.
- Using `D3D12MA::ALLOCATION_FLAG_NONE` in `Texture::Create`.
   - I think this is a better fit for the texture creation path, since it uses preallocated buffers instead of allocating separate regions. It seems to be the suggested path for small buffers, at least according to what I found online.
- Set `PreferredBlockSize` at 4MB instead of its default 64MB.
   - This seems critical for resource constrained runtimes, like the CI runner we have.
   - But it's also not great that we end up hard-coding this *lower than default* value across the entire runtime distribution just for a specific use case.
   - We really should make this configurable. [Once we have the infra in place](https://github.com/MonoGame/MonoGame/issues/9382) for that, we can revert this change.
   - Also, this is only done for Windows. I haven't changed the default in `_GAMING_XBOX` flow.
- Removed unused `m_transientBufferPool`.
   - We were allocating around 1.6 GB memory for this pool up front, but it's not used at all.
   - I'm not sure if it's leftover, or if it's intended to be used later on, so I've just commented it out for now.

Vulkan Change:
-
- Also, in `MGVK_BufferDiscard` in Vulkan, instead of hard-coding a `false`, we're deciding the `dynamic` argument based on buffer type.
   - According to the comments in the code, unless I misunderstand them, this should be `true` if the type is MGBufferType::Constant`.

Test Changes:
-
- Using absolute path in `FramePixelData.Save`.
   - This is not an issue normally, but it can cause test runs to crash on certain continuous testing setups.
ie. dotCover runs continuous testing process in a different location, causing the `SpaceShipModel` test to error out in my case.
- Setting `IsBackground` in `BackgroundLoading`.
   - If the main thread crashes, this allows the background thread to be killed by the host.

Results
-
With all these changes, we're eventually down from this:
https://github.com/MonoGame/MonoGame/actions/runs/28565615781/job/84694743566?pr=9407

~To this:~
~https://github.com/MonoGame/MonoGame/actions/runs/28567744279/job/84701534533?pr=9407~

To eventually this:
https://github.com/MonoGame/MonoGame/actions/runs/28627044531/job/84898795610?pr=9407

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

